### PR TITLE
Fix quotation marks in api.py

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -76,7 +76,7 @@ def convert_emoji_to_png(emoji, name):
     draw.text(draw_position, emoji, font=font, embedded_color=True)
     if is_blank_image(image):
         raise ValueError(f"Generated image for '{emoji}' is blank or unsupported.")
-    image.save(f'{icons_folder_path}/{name.replace(':', '')}.png', 'PNG')
+    image.save(f"{icons_folder_path}/{name.replace(':', '')}.png", 'PNG')
 
 def remove_skin_tones(emoji):
     skin_tone_range = range(0x1F3FB, 0x1F3FF + 1)


### PR DESCRIPTION
Inconsistent quotation mark placement on [line 79 of api.py][qm] caused the script to fail. Swapping `'` for `"` fixes the issue.

[qm]: https://github.com/BenjaminOddou/alfred-emoji-wine/blob/main/src/api.py#L79