### PR TITLE
Fix closing wine on faster machines

### DIFF
--- a/src/info.plist
+++ b/src/info.plist
@@ -160,7 +160,7 @@
 				<key>modifiersubtext</key>
 				<string></string>
 				<key>vitoclose</key>
-				<false/>
+				<true/>
 			</dict>
 		</array>
 		<key>5B589A8E-0D1A-4A17-9F2F-27D064B8F038</key>


### PR DESCRIPTION
When invoking `wine` via the keyword the window is closed when the machine is fast.

When an input field will show another input field afterwards the link between both should have `Don't close the Alfred Window on actioning result` activated.

This commit changes this for the link between the wine keyword and the Emoji-Wine script filter